### PR TITLE
GDPR Archive support

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "editor.codeActionsOnSave": {
+    "source.organizeImports": false
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,14 @@
 # Changelog
 
-This project uses [SemVer](https://semver.org/) for versioning. Its public APIs, runtime support, and documented file locations won't change incompatibly outside of major versions (once version 1.0.0 has been released).
+This project uses [SemVer](https://semver.org/) for versioning. Its public APIs, runtime support, and documented file locations won't change incompatibly outside of major versions (once version 1.0.0 has been released). There may be breaking schema changes in minor releases before 1.0.0 and will be noted in these release notes.
 
 ## 0.3.0
 
-_released `2023-05-XX`_
+_released `2023-05-23`_
 
-- adds the `archive` command, which loads data from a GDPR export. See the docs for more info
+- adds the `archive` command, which loads data from a Reddit GDPR archive ([#1](https://github.com/xavdid/reddit-user-to-sqlite/pull/1))
 - added more help text to both commands
+- provide more info about the counts of comments/posts saved/updated
 
 ## 0.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 This project uses [SemVer](https://semver.org/) for versioning. Its public APIs, runtime support, and documented file locations won't change incompatibly outside of major versions (once version 1.0.0 has been released).
 
+## 0.3.0
+
+_released `2023-05-XX`_
+
+- adds the `archive` command, which loads data from a GDPR export. See the docs for more info
+- added more help text to both commands
+
 ## 0.2.0
 
 _released `2023-05-07`_

--- a/README.md
+++ b/README.md
@@ -27,7 +27,18 @@ reddit-user-to-sqlite user your_username --db my-reddit-data.db
 
 > Note: the argument order is reversed from most dogsheep packages (which take db_path first). This method allows for use of a default db name, so I prefer it.
 
-1. `username`: a case-insensitive string. The leading `/u/` is optional (and ignored if supplied)
+1. `username`: a case-insensitive string. The leading `/u/` is optional (and ignored if supplied).
+2. (optional) `--db`: the path to a sqlite file, which will be created or updated as needed. Defaults to `reddit.db`.
+
+### archive
+
+Reads the output of a Reddit GDPR archive and fetches additional info from the Reddit API (where possible). This allows you to store more than 1k posts/comments.
+
+#### Params
+
+> Note: the argument order is reversed from most dogsheep packages (which take db_path first). This method allows for use of a default db name, so I prefer it.
+
+1. `archive_path`: the path to the (unzipped) archive directory on your machine. Don't rename/move the files that Reddit gives you.
 2. (optional) `--db`: the path to a sqlite file, which will be created or updated as needed. Defaults to `reddit.db`.
 
 ### A Note on Stored Data

--- a/README.md
+++ b/README.md
@@ -32,7 +32,9 @@ reddit-user-to-sqlite user your_username --db my-reddit-data.db
 
 ### archive
 
-Reads the output of a Reddit GDPR archive and fetches additional info from the Reddit API (where possible). This allows you to store more than 1k posts/comments.
+Reads the output of a [Reddit GDPR archive](https://support.reddithelp.com/hc/en-us/articles/360043048352-How-do-I-request-a-copy-of-my-Reddit-data-and-information-) and fetches additional info from the Reddit API (where possible). This allows you to store more than 1k posts/comments.
+
+> FYI: this behavior is built with the assumption that the archive that Reddit provides has the same format regardless of if you select `GDPR` or `CCPA` as the request type. But, just to be on the safe side, I recommend selecting `GDPR` during the export process until I'm able to confirm.
 
 #### Params
 
@@ -40,10 +42,6 @@ Reads the output of a Reddit GDPR archive and fetches additional info from the R
 
 1. `archive_path`: the path to the (unzipped) archive directory on your machine. Don't rename/move the files that Reddit gives you.
 2. (optional) `--db`: the path to a sqlite file, which will be created or updated as needed. Defaults to `reddit.db`.
-
-### A Note on Stored Data
-
-While most [Dogsheep](https://github.com/dogsheep) projects grab the raw JSON output of their source APIs, Reddit's API has a lot of junk in it. So, I opted for a slimmed down approach.
 
 ## Viewing Data
 
@@ -137,9 +135,19 @@ I got nervous when I saw Reddit's [notification of upcoming API changes](https:/
 
 If a post is removed, only the mods and the user who posted it can see its text. Since this tool currently runs without any authentication, those removed posts can't be fetched via the API.
 
+To fetch data about your own removed posts, use the GDPR archive import
 This will be fixed in a future release, either by:
 
-- (planned) being able to pull data from a GDPR archive
-- (maybe) adding support for authentication, so you can see your own posts
+### Why is the database missing data returned by the Reddit API?
 
-https://www.reddit.com/r/modnews/comments/py2xy2/voting_commenting_on_archived_posts/
+While most [Dogsheep](https://github.com/dogsheep) projects grab the raw JSON output of their source APIs, Reddit's API has a lot of junk in it. So, I opted for a slimmed down approach.
+
+If there's a field missing that you think would be useful, feel free to open an issue!
+
+### Does this tool refetch old data?
+
+When running the `user` command, yes. It fetches and updates up to 1k each of comments and posts and updates the local copy.
+
+When running the `archive` command, no. To cut down on API requests, it only fetches data about comments/posts that aren't yet in the database (since the archive may include many items).
+
+Both of these may change in the future to be more in line with [Reddit's per-subreddit archiving guidelines](https://www.reddit.com/r/modnews/comments/py2xy2/voting_commenting_on_archived_posts/).

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ When in a virtual environment, run the following:
 pip install -e '.[test]'
 ```
 
-This installs the package in `--edit` mode and makes its dependencies available.
+This installs the package in `--edit` mode and makes its dependencies available. You can now run `reddit-user-to-sqlite` to invoke the CLI.
 
 ### Running Tests
 
@@ -130,3 +130,5 @@ This will be fixed in a future release, either by:
 
 - (planned) being able to pull data from a GDPR archive
 - (maybe) adding support for authentication, so you can see your own posts
+
+https://www.reddit.com/r/modnews/comments/py2xy2/voting_commenting_on_archived_posts/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 keywords = ["sqlite", "reddit", "dogsheep"]
 
 dependencies = [
-  "sqlite-utils==3.30",
+  "sqlite-utils==3.32.1",
   "click==8.1.3",
   "requests==2.29.0",
   "tqdm==4.65.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "reddit-user-to-sqlite"
-version = "0.2.0"
+version = "0.3.0"
 
 authors = [{ name = "David Brownman", email = "beamneocube@gmail.com" }]
 description = "Create a SQLite database containing data pulled from Reddit about a single user."

--- a/reddit_user_to_sqlite/cli.py
+++ b/reddit_user_to_sqlite/cli.py
@@ -1,8 +1,9 @@
 from csv import DictReader
+from functools import partial
 from itertools import chain
 from pathlib import Path
 from pprint import pprint
-from typing import cast
+from typing import Callable, Iterable, Literal, TypeVar, cast
 
 import click
 from sqlite_utils import Database
@@ -34,6 +35,23 @@ def cli():
 DB_PATH_HELP = "A path to a SQLite database file. If it doesn't exist, it will be created. It can have any extension, but I'd recommend `.db` or `.sqlite`."
 DEFAULT_DB_NAME = "reddit.db"
 
+T = TypeVar("T", Comment, Post)
+
+
+def _save_items(
+    db: Database, items: list[T], upsert_func: Callable[[Database, Iterable[T]], int]
+):
+    if items:
+        # TODO: handle no items have a user_fullname
+        # insert_user(db, next(c for c in comments if "author_fullname" in c))
+        insert_user(db, items[0])
+        insert_subreddits(db, items)
+        upsert_func(db, items)
+
+
+save_comments = partial(_save_items, upsert_func=upsert_comments)
+save_posts = partial(_save_items, upsert_func=upsert_posts)
+
 
 @cli.command()
 @click.argument("username")
@@ -48,27 +66,42 @@ def user(db_path: str, username: str):
     username = clean_username(username)
     click.echo(f"loading data about /u/{username} into {db_path}\n")
 
+    db = Database(db_path)
+
     click.echo("fetching (up to 10 pages of) comments")
     comments = load_comments_for_user(username)
-
-    db = Database(db_path)
-    if comments:
-        insert_user(db, comments[0])
-        insert_subreddits(db, comments)
-        upsert_comments(db, comments)
+    save_comments(db, comments)
 
     click.echo("\nfetching (up to 10 pages of) posts")
-
     posts = load_posts_for_user(username)
-    if posts:
-        insert_user(db, posts[0])
-        insert_subreddits(db, posts)
-        upsert_posts(db, posts)
+    save_posts(db, posts)
 
     if not (comments or posts):
         raise click.ClickException(f"no data found for username: {username}")
 
     ensure_fts(db)
+
+
+ItemType = Literal["comments", "posts"]
+
+
+def load_ids_from_file(
+    db: Database, archive_path: Path, item_type: ItemType
+) -> list[str]:
+    filename = f"{item_type}.csv"
+    if not (file := archive_path / filename).exists():
+        raise ValueError(
+            f'Ensure path "{archive_path}" points to an unzipped Reddit GDPR archive folder; {filename} not found in the expected spot.'
+        )
+
+    saved_ids = {row["id"] for row in db[item_type].rows}
+
+    with open(file) as comment_archive_rows:
+        return [
+            f't1_{c["id"]}'
+            for c in DictReader(comment_archive_rows)
+            if c["id"] not in saved_ids
+        ]
 
 
 @cli.command()
@@ -84,61 +117,13 @@ def user(db_path: str, username: str):
     help=DB_PATH_HELP,
 )
 def archive(archive_path: Path, db_path: str):
-    if not (comments_file := archive_path / "comments.csv").exists():
-        raise ValueError(
-            f'Ensure path "{archive_path}" points to an unzipped Reddit GDPR archive; comments.csv not found in the expected spot.'
-        )
-
+    # TODO: add text
     db = Database(db_path)
-    existing_comment_ids = {row["id"] for row in db["comments"].rows}
 
-    with open(comments_file) as comment_archive_rows:
-        comments_to_fetch = [
-            f't1_{c["id"]}'
-            for c in DictReader(comment_archive_rows)
-            if c["id"] not in existing_comment_ids
-        ]
+    comment_ids = load_ids_from_file(db, archive_path, "comments")
+    comments = cast(list[Comment], load_info(comment_ids))
+    num_written = save_comments(db, comments)
 
-    comments = cast(
-        list[Comment],
-        list(
-            chain.from_iterable(
-                load_info(batch) for batch in batched(tqdm(comments_to_fetch), 100)
-            )
-        ),
-    )
-
-    if comments:
-        # TODO: handle all rows having bad data
-        # insert_user(db, next(c for c in comments if "author_fullname" in c))
-        insert_subreddits(db, comments)
-        upsert_comments(db, comments)
-
-    if not (posts_file := archive_path / "posts.csv").exists():
-        raise ValueError(
-            f'Ensure path "{archive_path}" points to an unzipped Reddit GDPR archive; posts.csv not found in the expected spot.'
-        )
-
-    existing_post_ids = {row["id"] for row in db["posts"].rows}
-
-    with open(posts_file) as post_archive_rows:
-        posts_to_fetch = [
-            f't3_{p["id"]}'
-            for p in DictReader(post_archive_rows)
-            if p["id"] not in existing_post_ids
-        ]
-
-    posts = cast(
-        list[Post],
-        list(
-            chain.from_iterable(
-                load_info(batch) for batch in batched(tqdm(posts_to_fetch), 100)
-            )
-        ),
-    )
-
-    if posts:
-        # TODO: handle all rows having bad data
-        # insert_user(db, next(p for p in posts if "author_fullname" in p))
-        insert_subreddits(db, posts)
-        upsert_posts(db, posts)
+    post_ids = load_ids_from_file(db, archive_path, "posts")
+    posts = cast(list[Post], load_info(post_ids))
+    num_written = save_posts(db, posts)

--- a/reddit_user_to_sqlite/cli.py
+++ b/reddit_user_to_sqlite/cli.py
@@ -120,11 +120,12 @@ def archive(archive_path: Path, db_path: str):
     if not (any_object_has_username(comments) or any_object_has_username(posts)):
         if username := get_username_from_archive(archive_path):
             user_id = get_user_id(username)
+
             comments = add_user_fragment(comments, username, user_id)
             posts = add_user_fragment(posts, username, user_id)
         else:
             click.echo(
-                "\nUnable to guess username from content or archive; some posts will not be saved.",
+                "\nUnable to guess username from API content or archive; some posts will not be saved.",
                 err=True,
             )
 

--- a/reddit_user_to_sqlite/cli.py
+++ b/reddit_user_to_sqlite/cli.py
@@ -9,7 +9,7 @@ from reddit_user_to_sqlite.csv_helpers import (
     get_username_from_archive,
     load_ids_from_file,
 )
-from reddit_user_to_sqlite.helpers import clean_username, find_object_with_username
+from reddit_user_to_sqlite.helpers import clean_username, any_object_has_username
 from reddit_user_to_sqlite.reddit_api import (
     Comment,
     Post,
@@ -117,12 +117,8 @@ def archive(archive_path: Path, db_path: str):
     click.echo("\nFetching info about posts")
     posts = cast(list[Post], load_info(post_ids))
 
-    obj_with_username = find_object_with_username(
-        comments
-    ) or find_object_with_username(posts)
-    if not obj_with_username:
-        username = get_username_from_archive(archive_path)
-        if username:
+    if not (any_object_has_username(comments) or any_object_has_username(posts)):
+        if username := get_username_from_archive(archive_path):
             user_id = get_user_id(username)
             comments = add_user_fragment(comments, username, user_id)
             posts = add_user_fragment(posts, username, user_id)

--- a/reddit_user_to_sqlite/cli.py
+++ b/reddit_user_to_sqlite/cli.py
@@ -1,8 +1,20 @@
+from csv import DictReader
+from itertools import chain
+from pathlib import Path
+from pprint import pprint
+from typing import cast
+
 import click
 from sqlite_utils import Database
+from tqdm import tqdm
 
-from reddit_user_to_sqlite.helpers import clean_username
-from reddit_user_to_sqlite.reddit_api import load_comments_for_user, load_posts_for_user
+from reddit_user_to_sqlite.helpers import batched, clean_username
+from reddit_user_to_sqlite.reddit_api import (
+    Comment,
+    load_comments_for_user,
+    load_info,
+    load_posts_for_user,
+)
 from reddit_user_to_sqlite.sqlite_helpers import (
     ensure_fts,
     insert_subreddits,
@@ -18,15 +30,20 @@ def cli():
     "Save data from Reddit to a SQLite database"
 
 
+DB_PATH_HELP = "A path to a SQLite database file. If it doesn't exist, it will be created. It can have any extension, but I'd recommend `.db` or `.sqlite`."
+DEFAULT_DB_NAME = "reddit.db"
+
+
 @cli.command()
 @click.argument("username")
 @click.option(
     "--db",
     "db_path",
     type=click.Path(file_okay=True, dir_okay=False, allow_dash=False),
-    default="reddit.db",
+    default=DEFAULT_DB_NAME,
+    help=DB_PATH_HELP,
 )
-def user(db_path, username):
+def user(db_path: str, username: str):
     username = clean_username(username)
     click.echo(f"loading data about /u/{username} into {db_path}\n")
 
@@ -51,3 +68,49 @@ def user(db_path, username):
         raise click.ClickException(f"no data found for username: {username}")
 
     ensure_fts(db)
+
+
+@cli.command()
+@click.argument(
+    "archive_path",
+    type=click.Path(file_okay=False, dir_okay=True, allow_dash=False, path_type=Path),
+)
+@click.option(
+    "--db",
+    "db_path",
+    type=click.Path(file_okay=True, dir_okay=False, allow_dash=False),
+    default=DEFAULT_DB_NAME,
+    help=DB_PATH_HELP,
+)
+def archive(archive_path: Path, db_path: str):
+    if not (comments_file := archive_path / "comments.csv").exists():
+        raise ValueError(
+            f'Ensure path "{archive_path}" points to an unzipped Reddit GDPR archive; comments.csv not found in the expected post.'
+        )
+
+    db = Database(db_path)
+    existing_ids = {row["id"] for row in db["comments"].rows}
+
+    with open(comments_file) as comment_archive_rows:
+        comments_to_fetch = [
+            f't1_{c["id"]}'
+            for c in DictReader(comment_archive_rows)
+            if c["id"] not in existing_ids
+        ]
+
+    # comments_to_fetch = comments_to_fetch[:50]
+
+    comments = cast(
+        list[Comment],
+        list(
+            chain.from_iterable(
+                load_info(batch) for batch in batched(tqdm(comments_to_fetch), 100)
+            )
+        ),
+    )
+
+    if comments:
+        # TODO: handle all rows having bad data
+        insert_user(db, next(c for c in comments if "author_fullname" in c))
+        insert_subreddits(db, comments)
+        upsert_comments(db, comments)

--- a/reddit_user_to_sqlite/csv_helpers.py
+++ b/reddit_user_to_sqlite/csv_helpers.py
@@ -1,3 +1,42 @@
-import csv
+from csv import DictReader
+from pathlib import Path
+from typing import Literal
 
-# id,permalink,date,ip,subreddit,gildings,link,parent,body,media
+from sqlite_utils import Database
+
+ItemType = Literal["comments", "posts"]
+PREFIX: dict[ItemType, str] = {"comments": "t1", "posts": "t3"}
+
+
+def validate_and_build_path(archive_path: Path, item_type: str) -> Path:
+    filename = f"{item_type}.csv"
+    if not (file := archive_path / filename).exists():
+        raise ValueError(
+            f'Ensure path "{archive_path}" points to an unzipped Reddit GDPR archive folder; {filename} not found in the expected spot.'
+        )
+    return file
+
+
+def load_ids_from_file(
+    db: Database, archive_path: Path, item_type: ItemType
+) -> list[str]:
+    saved_ids = {row["id"] for row in db[item_type].rows}
+
+    with open(validate_and_build_path(archive_path, item_type)) as comment_archive_rows:
+        return [
+            f'{PREFIX[item_type]}_{c["id"]}'
+            for c in DictReader(comment_archive_rows)
+            if c["id"] not in saved_ids
+        ]
+
+
+def get_username_from_archive(archive_path: Path) -> str | None:
+    with open(validate_and_build_path(archive_path, "statistics")) as stat_rows:
+        try:
+            return next(
+                row["value"]
+                for row in DictReader(stat_rows)
+                if row["statistic"] == "account name"
+            )
+        except StopIteration:
+            pass

--- a/reddit_user_to_sqlite/csv_helpers.py
+++ b/reddit_user_to_sqlite/csv_helpers.py
@@ -1,0 +1,3 @@
+import csv
+
+# id,permalink,date,ip,subreddit,gildings,link,parent,body,media

--- a/reddit_user_to_sqlite/helpers.py
+++ b/reddit_user_to_sqlite/helpers.py
@@ -1,7 +1,6 @@
 import re
 from itertools import islice
-from typing import Iterable, TypeVar, TYPE_CHECKING
-
+from typing import Iterable, TypeVar
 
 T = TypeVar("T")
 

--- a/reddit_user_to_sqlite/helpers.py
+++ b/reddit_user_to_sqlite/helpers.py
@@ -1,4 +1,20 @@
 import re
+from itertools import islice
+from typing import Iterable, TypeVar
+
+T = TypeVar("T")
+
+
+# https://docs.python.org/3.11/library/itertools.html#itertools-recipes
+# available natively in 3.12
+def batched(iterable: Iterable[T], n: int) -> Iterable[tuple[T]]:
+    "Batch data into tuples of length n. The last batch may be shorter."
+    # batched('ABCDEFG', 3) --> ABC DEF G
+    if n < 1:
+        raise ValueError("n must be at least one")
+    it = iter(iterable)
+    while batch := tuple(islice(it, n)):
+        yield batch
 
 
 def clean_username(username: str) -> str:

--- a/reddit_user_to_sqlite/helpers.py
+++ b/reddit_user_to_sqlite/helpers.py
@@ -27,8 +27,13 @@ def clean_username(username: str) -> str:
     return username
 
 
-def any_object_has_username(items) -> bool:
+def find_user_details_from_items(items) -> tuple[str, str] | None:
+    """
+    Returns a 2-tuple of prefixed user_id and username if found, otherwise None
+    """
     try:
-        return bool(next(c for c in items if "author_fullname" in c))
+        return next(
+            (c["author"], c["author_fullname"]) for c in items if "author_fullname" in c
+        )
     except StopIteration:
-        return False
+        return None

--- a/reddit_user_to_sqlite/helpers.py
+++ b/reddit_user_to_sqlite/helpers.py
@@ -1,6 +1,7 @@
 import re
 from itertools import islice
-from typing import Iterable, TypeVar
+from typing import Iterable, TypeVar, TYPE_CHECKING
+
 
 T = TypeVar("T")
 
@@ -24,3 +25,10 @@ def clean_username(username: str) -> str:
     if re.match(r"/?u/", username):
         return username.strip().strip("/u")
     return username
+
+
+def find_object_with_username(items):
+    try:
+        return next(c for c in items if "author_fullname" in c)
+    except StopIteration:
+        pass

--- a/reddit_user_to_sqlite/helpers.py
+++ b/reddit_user_to_sqlite/helpers.py
@@ -27,8 +27,8 @@ def clean_username(username: str) -> str:
     return username
 
 
-def find_object_with_username(items):
+def any_object_has_username(items) -> bool:
     try:
-        return next(c for c in items if "author_fullname" in c)
+        return bool(next(c for c in items if "author_fullname" in c))
     except StopIteration:
-        pass
+        return False

--- a/reddit_user_to_sqlite/reddit_api.py
+++ b/reddit_user_to_sqlite/reddit_api.py
@@ -1,12 +1,4 @@
-from typing import (
-    Any,
-    Literal,
-    NotRequired,
-    Optional,
-    Sequence,
-    TypedDict,
-    final,
-)
+from typing import Any, Literal, NotRequired, Optional, Sequence, TypedDict, final
 
 import requests
 from tqdm import tqdm, trange

--- a/reddit_user_to_sqlite/reddit_api.py
+++ b/reddit_user_to_sqlite/reddit_api.py
@@ -178,6 +178,7 @@ def load_posts_for_user(username: str) -> list[Post]:
 
 
 def load_info(resources: Sequence[str]) -> list[Comment | Post | Subreddit]:
+    print("loading info", resources)
     result = []
 
     for batch in batched(tqdm(resources), PAGE_SIZE):

--- a/reddit_user_to_sqlite/reddit_api.py
+++ b/reddit_user_to_sqlite/reddit_api.py
@@ -88,14 +88,14 @@ class Post(SubredditFragment, UserFragment):
     created: float
 
 
-class Subreddit(TypedDict):
-    should_archive_posts: bool
+# class Subreddit(TypedDict):
+#     should_archive_posts: bool
 
 
 @final
 class ResourceWrapper(TypedDict):
     kind: str
-    data: Comment | Post | Subreddit
+    data: Comment | Post
 
 
 @final
@@ -169,7 +169,7 @@ def load_posts_for_user(username: str) -> list[Post]:
     return _load_paged_resource("submitted", username)
 
 
-def load_info(resources: Sequence[str]) -> list[Comment | Post | Subreddit]:
+def load_info(resources: Sequence[str]) -> list[Comment | Post]:
     result = []
 
     for batch in batched(tqdm(resources), PAGE_SIZE):

--- a/reddit_user_to_sqlite/reddit_api.py
+++ b/reddit_user_to_sqlite/reddit_api.py
@@ -178,7 +178,6 @@ def load_posts_for_user(username: str) -> list[Post]:
 
 
 def load_info(resources: Sequence[str]) -> list[Comment | Post | Subreddit]:
-    print("loading info", resources)
     result = []
 
     for batch in batched(tqdm(resources), PAGE_SIZE):

--- a/reddit_user_to_sqlite/sqlite_helpers.py
+++ b/reddit_user_to_sqlite/sqlite_helpers.py
@@ -50,7 +50,6 @@ def item_to_user_row(item: UserFragment) -> dict[str, str] | None:
 
 def insert_user(db: Database, user: UserFragment):
     if user_row := item_to_user_row(user):
-        print("uu", user_row)
         # don't really want to upsert, but I get errors from sqlite when I `insert` after an insert_all
         # https://github.com/simonw/sqlite-utils/issues/554
         db["users"].upsert(  # type: ignore

--- a/reddit_user_to_sqlite/sqlite_helpers.py
+++ b/reddit_user_to_sqlite/sqlite_helpers.py
@@ -131,27 +131,32 @@ class PostRow(TypedDict):
 
 
 def post_to_post_row(post: Post) -> PostRow:
-    return {
-        "id": post["id"],
-        "timestamp": int(post["created"]),
-        "score": post["score"],
-        "num_comments": post["num_comments"],
-        "title": post["title"],
-        "text": post["selftext"],
-        "external_url": "" if "reddit.com" in post["url"] else post["url"],
-        "user": post["author_fullname"][3:],
-        "subreddit": post["subreddit_id"][3:],
-        "permalink": f'https://old.reddit.com{post["permalink"]}',
-        "upvote_ratio": post["upvote_ratio"],
-        "score": post["score"],
-        "num_awards": post["total_awards_received"],
-        "is_removed": int(post["selftext"] == "[removed]"),
-    }
+    try:
+        return {
+            "id": post["id"],
+            "timestamp": int(post["created"]),
+            "score": post["score"],
+            "num_comments": post["num_comments"],
+            "title": post["title"],
+            "text": post["selftext"],
+            "external_url": "" if "reddit.com" in post["url"] else post["url"],
+            "user": post["author_fullname"][3:],
+            "subreddit": post["subreddit_id"][3:],
+            "permalink": f'https://old.reddit.com{post["permalink"]}',
+            "upvote_ratio": post["upvote_ratio"],
+            "score": post["score"],
+            "num_awards": post["total_awards_received"],
+            "is_removed": int(post["selftext"] == "[removed]"),
+        }
+    except KeyError:
+        print(f"failed on {post['id']}")
+        # TODO: handle removed comments better
+        pass
 
 
 def upsert_posts(db: Database, posts: list[Post]):
     db["posts"].insert_all(  # type: ignore
-        map(post_to_post_row, posts),
+        [p for p in map(post_to_post_row, posts) if p],
         upsert=True,
         pk="id",  # type: ignore
         alter=True,  # type: ignore

--- a/reddit_user_to_sqlite/sqlite_helpers.py
+++ b/reddit_user_to_sqlite/sqlite_helpers.py
@@ -42,19 +42,21 @@ class UserRow(TypedDict):
     username: str
 
 
-def comment_to_user_row(comment: UserFragment) -> UserRow:
-    return {"id": comment["author_fullname"][3:], "username": comment["author"]}
+def comment_to_user_row(user: UserFragment) -> dict[str, str] | None:
+    if "author_fullname" in user:
+        return {"id": user["author_fullname"][3:], "username": user["author"]}
 
 
 def insert_user(db: Database, user: UserFragment):
-    db["users"].insert(  # type: ignore
-        cast(dict[str, Any], comment_to_user_row(user)),
-        # ignore any write error
-        ignore=True,
-        # only relevant if creating the table
-        pk="id",  # type: ignore
-        not_null=["id", "username"],
-    )
+    if user_row := comment_to_user_row(user):
+        db["users"].insert(  # type: ignore
+            user_row,
+            # ignore any write error
+            ignore=True,
+            # only relevant if creating the table
+            pk="id",  # type: ignore
+            not_null=["id", "username"],
+        )
 
 
 class CommentRow(TypedDict):

--- a/reddit_user_to_sqlite/sqlite_helpers.py
+++ b/reddit_user_to_sqlite/sqlite_helpers.py
@@ -1,5 +1,4 @@
-from pprint import pprint
-from typing import Any, Callable, Iterable, Sequence, TypeVar, TypedDict, cast
+from typing import Callable, Iterable, TypedDict, TypeVar
 
 from sqlite_utils import Database
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Any, Generator, Literal, Optional, Protocol, Sequence
+from typing import Any, Generator, Literal, Optional, Protocol
 
 import pytest
 import responses

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ from responses import BaseResponse, RequestsMock, matchers
 from sqlite_utils import Database
 
 from reddit_user_to_sqlite.reddit_api import USER_AGENT, Post, SuccessResponse
-from reddit_user_to_sqlite.sqlite_helpers import CommentRow, PostRow
+from reddit_user_to_sqlite.sqlite_helpers import CommentRow, PostRow, UserRow
 
 
 @pytest.fixture
@@ -240,6 +240,7 @@ def stored_removed_comment() -> CommentRow:
         "subreddit": "2qm4e",
         "text": "[removed]",
         "timestamp": 1329550785,
+        # manually added this - if it's stored, I must have found a user
         "user": "np8mb41h",
     }
 
@@ -549,6 +550,7 @@ def stored_removed_post() -> PostRow:
         "timestamp": 1369671390,
         "title": "Tommy Wiseau Wishes YOU A Happy Memorial Day! — Urban Outfitters",
         "upvote_ratio": 1.0,
+        # manually added this - if it's stored, I must have found a user
         "user": "np8mb41h",
     }
 
@@ -663,6 +665,11 @@ def mock_info_request() -> Generator[MockInfoFunc, None, None]:
     """
     with responses.RequestsMock() as mock:
         yield _build_mock_info_req(mock)
+
+
+@pytest.fixture
+def stored_user() -> UserRow:
+    return {"id": "np8mb41h", "username": "xavdid"}
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,7 @@ from typing import Any, Generator, Literal, Optional, Protocol, Sequence
 
 import pytest
 import responses
-from responses import BaseResponse, matchers
+from responses import BaseResponse, RequestsMock, matchers
 from sqlite_utils import Database
 
 from reddit_user_to_sqlite.reddit_api import USER_AGENT, Post, SuccessResponse
@@ -126,6 +126,92 @@ def comment():
 
 
 @pytest.fixture
+def modify_comment(comment):
+    def _modify(d):
+        return {**comment, **d}
+
+    return _modify
+
+
+@pytest.fixture
+def modify_post(self_post):
+    def _modify(d):
+        return {**self_post, **d}
+
+    return _modify
+
+
+@pytest.fixture
+def removed_comment():
+    return {
+        "total_awards_received": 0,
+        "approved_at_utc": None,
+        "author_is_blocked": False,
+        "comment_type": None,
+        "edited": False,
+        "mod_reason_by": None,
+        "banned_by": None,
+        "removal_reason": None,
+        "link_id": "t3_puwue",
+        "author_flair_template_id": None,
+        "likes": None,
+        "replies": "",
+        "user_reports": [],
+        "saved": False,
+        "id": "c3sgfl4",
+        "banned_at_utc": None,
+        "mod_reason_title": None,
+        "gilded": 0,
+        "archived": True,
+        "collapsed_reason_code": "DELETED",
+        "no_follow": True,
+        "author": "[deleted]",
+        "can_mod_post": False,
+        "created_utc": 1329550785.0,
+        "send_replies": True,
+        "parent_id": "t1_c3sgeij",
+        "score": -1,
+        "approved_by": None,
+        "mod_note": None,
+        "all_awardings": [],
+        "subreddit_id": "t5_2qm4e",
+        "body": "[removed]",
+        "awarders": [],
+        "author_flair_css_class": None,
+        "name": "t1_c3sgfl4",
+        "downs": 0,
+        "is_submitter": False,
+        "body_html": '<div class="md"><p>[removed]</p>\n</div>',
+        "gildings": {},
+        "collapsed_reason": None,
+        "distinguished": None,
+        "associated_award": None,
+        "stickied": False,
+        "can_gild": True,
+        "top_awarded_type": None,
+        "unrepliable_reason": None,
+        "author_flair_text_color": "dark",
+        "score_hidden": False,
+        "permalink": "/r/askscience/comments/asdf/why_do_birds_fly/",
+        "num_reports": None,
+        "locked": False,
+        "report_reasons": None,
+        "created": 1329550785.0,
+        "subreddit": "askscience",
+        "author_flair_text": None,
+        "treatment_tags": [],
+        "collapsed": True,
+        "subreddit_name_prefixed": "r/askscience",
+        "controversiality": 0,
+        "author_flair_background_color": "",
+        "collapsed_because_crowd_control": None,
+        "mod_reports": [],
+        "subreddit_type": "public",
+        "ups": -1,
+    }
+
+
+@pytest.fixture
 def stored_comment() -> CommentRow:
     """
     a serialized comment row in the db
@@ -139,6 +225,21 @@ def stored_comment() -> CommentRow:
         "subreddit": "2t3ad",
         "text": "Such a great game to pick up for a run every couple of months. Every time I think I'm done, it pulls be back in.",
         "timestamp": 1683327131,
+        "user": "np8mb41h",
+    }
+
+
+@pytest.fixture
+def stored_removed_comment() -> CommentRow:
+    return {
+        "controversiality": 0,
+        "id": "c3sgfl4",
+        "is_submitter": 0,
+        "permalink": "https://old.reddit.com/r/askscience/comments/asdf/why_do_birds_fly/?context=10",
+        "score": -1,
+        "subreddit": "2qm4e",
+        "text": "[removed]",
+        "timestamp": 1329550785,
         "user": "np8mb41h",
     }
 
@@ -323,24 +424,132 @@ def self_post_response(self_post):
 
 
 @pytest.fixture
-def removed_post(self_post: Post) -> Post:
+def removed_post():
     """
     A raw (unwrapped) removed post object from the Reddit API
     """
     return {
-        **self_post,
-        "selftext": "[removed]",
-        "id": "asdf",
+        "approved_at_utc": None,
+        "subreddit": "videos",
+        "selftext": "[deleted]",
+        "user_reports": [],
+        "saved": False,
+        "mod_reason_title": None,
+        "gilded": 0,
+        "clicked": False,
+        "title": "Tommy Wiseau Wishes YOU A Happy Memorial Day! — Urban Outfitters",
+        "link_flair_richtext": [],
+        "subreddit_name_prefixed": "r/videos",
+        "hidden": False,
+        "pwls": 6,
+        "link_flair_css_class": None,
+        "downs": 0,
+        "thumbnail_height": 52,
+        "top_awarded_type": None,
+        "hide_score": False,
+        "name": "t3_1f55rr",
+        "quarantine": False,
+        "link_flair_text_color": "dark",
+        "upvote_ratio": 1.0,
+        "author_flair_background_color": "",
+        "subreddit_type": "public",
+        "ups": 1,
+        "total_awards_received": 0,
+        "media_embed": {},
+        "thumbnail_width": 70,
+        "author_flair_template_id": None,
+        "is_original_content": False,
+        "secure_media": None,
+        "is_reddit_media_domain": False,
+        "is_meta": False,
+        "category": None,
+        "secure_media_embed": {},
+        "link_flair_text": None,
+        "can_mod_post": False,
+        "score": 1,
+        "approved_by": None,
+        "is_created_from_ads_ui": False,
+        "thumbnail": "default",
+        "edited": False,
+        "author_flair_css_class": None,
+        "gildings": {},
+        "content_categories": None,
+        "is_self": False,
+        "mod_note": None,
+        "created": 1369671390.0,
+        "link_flair_type": "text",
+        "wls": 6,
+        "removed_by_category": None,
+        "banned_by": None,
+        "domain": "",
+        "allow_live_comments": False,
+        "selftext_html": '<!-- SC_OFF --><div class="md"><p>[deleted]</p>\n</div><!-- SC_ON -->',
+        "likes": None,
+        "suggested_sort": None,
+        "banned_at_utc": None,
+        "url_overridden_by_dest": "",
+        "view_count": None,
+        "archived": False,
+        "no_follow": True,
+        "is_crosspostable": False,
+        "pinned": False,
+        "over_18": False,
+        "all_awardings": [],
+        "awarders": [],
+        "media_only": False,
+        "can_gild": False,
+        "spoiler": False,
+        "locked": False,
+        "author_flair_text": None,
+        "treatment_tags": [],
+        "visited": False,
+        "removed_by": None,
+        "num_reports": None,
+        "distinguished": None,
+        "subreddit_id": "t5_2qh1e",
+        "author_is_blocked": False,
+        "mod_reason_by": None,
+        "removal_reason": None,
+        "link_flair_background_color": "",
+        "id": "1f55rr",
+        "is_robot_indexable": False,
+        "report_reasons": None,
+        "author": "[deleted]",
+        "discussion_type": None,
+        "num_comments": 0,
+        "send_replies": False,
+        "whitelist_status": "all_ads",
+        "contest_mode": False,
+        "mod_reports": [],
+        "author_flair_text_color": "dark",
+        "permalink": "/r/videos/comments/1f55rr/tommy_wiseau_wishes_you_a_happy_memorial_day/",
+        "parent_whitelist_status": "all_ads",
+        "stickied": False,
+        "url": "",
+        "subreddit_subscribers": 26688085,
+        "created_utc": 1369671390.0,
+        "num_crossposts": 0,
+        "media": None,
+        "is_video": False,
     }
 
 
 @pytest.fixture
-def stored_removed_post(stored_self_post: PostRow) -> PostRow:
+def stored_removed_post() -> PostRow:
     return {
-        **stored_self_post,
-        "text": "[removed]",
-        "is_removed": 1,
-        "id": "asdf",
+        "external_url": "",
+        "id": "1f55rr",
+        "is_removed": 0,
+        "num_awards": 0,
+        "num_comments": 0,
+        "permalink": "https://old.reddit.com/r/videos/comments/1f55rr/tommy_wiseau_wishes_you_a_happy_memorial_day/",
+        "score": 1,
+        "subreddit": "2qh1e",
+        "text": "[deleted]",
+        "timestamp": 1369671390,
+        "title": "Tommy Wiseau Wishes YOU A Happy Memorial Day! — Urban Outfitters",
+        "upvote_ratio": 1.0,
+        "user": "np8mb41h",
     }
 
 
@@ -392,35 +601,59 @@ class MockPagedFunc(Protocol):
         ...
 
 
+def _build_mock_paged_req(mock: RequestsMock) -> MockPagedFunc:
+    def _mock_request(
+        resource: Literal["comments", "submitted"],
+        json: Any,
+        params: Optional[dict[str, str | int]] = None,
+    ):
+        params = {"limit": 100, "raw_json": 1, **(params or {})}
+
+        return mock.get(
+            f"https://www.reddit.com/user/xavdid/{resource}.json",
+            match=[
+                matchers.query_param_matcher(params),
+                matchers.header_matcher({"user-agent": USER_AGENT}),
+            ],
+            json=json,
+        )
+
+    return _mock_request
+
+
 @pytest.fixture
 def mock_paged_request() -> Generator[MockPagedFunc, None, None]:
     """
     call this to mock a list of items for a user
     """
     with responses.RequestsMock() as mock:
-
-        def _mock_request(
-            resource: Literal["comments", "submitted"],
-            json: Any,
-            params: Optional[dict[str, str | int]] = None,
-        ):
-            params = {"limit": 100, "raw_json": 1, **(params or {})}
-
-            return mock.get(
-                f"https://www.reddit.com/user/xavdid/{resource}.json",
-                match=[
-                    matchers.query_param_matcher(params),
-                    matchers.header_matcher({"user-agent": USER_AGENT}),
-                ],
-                json=json,
-            )
-
-        yield _mock_request
+        yield _build_mock_paged_req(mock)
 
 
 class MockInfoFunc(Protocol):
     def __call__(self, ids: str, json: Any, limit=100) -> BaseResponse:
         ...
+
+
+# need to extract this so I can call it manually
+def _build_mock_info_req(mock: RequestsMock) -> MockInfoFunc:
+    def _mock_request(
+        ids: str,
+        json: Any,
+        limit=100,
+    ):
+        params = {"limit": limit, "raw_json": 1, "id": ids}
+
+        return mock.get(
+            "https://www.reddit.com/api/info.json",
+            match=[
+                matchers.query_param_matcher(params),
+                matchers.header_matcher({"user-agent": USER_AGENT}),
+            ],
+            json=json,
+        )
+
+    return _mock_request
 
 
 @pytest.fixture
@@ -429,24 +662,7 @@ def mock_info_request() -> Generator[MockInfoFunc, None, None]:
     call this to mirror loading info about a sequence of fullnames (type-prefixed ids)
     """
     with responses.RequestsMock() as mock:
-
-        def _mock_request(
-            ids: str,
-            json: Any,
-            limit=100,
-        ):
-            params = {"limit": limit, "raw_json": 1, "id": ids}
-
-            return mock.get(
-                "https://www.reddit.com/api/info.json",
-                match=[
-                    matchers.query_param_matcher(params),
-                    matchers.header_matcher({"user-agent": USER_AGENT}),
-                ],
-                json=json,
-            )
-
-        yield _mock_request
+        yield _build_mock_info_req(mock)
 
 
 @pytest.fixture
@@ -529,23 +745,26 @@ class MockUserFunc(Protocol):
         ...
 
 
+def _build_mock_user_request(mock: RequestsMock) -> MockUserFunc:
+    def _mock_request(username: str, json: Any):
+        return mock.get(
+            f"https://www.reddit.com/user/{username}/about.json",
+            match=[
+                matchers.header_matcher({"user-agent": USER_AGENT}),
+            ],
+            json=json,
+        )
+
+    return _mock_request
+
+
 @pytest.fixture
 def mock_user_request() -> Generator[MockUserFunc, None, None]:
     """
     call this to mirror loading info about a sequence of fullnames (type-prefixed ids)
     """
     with responses.RequestsMock() as mock:
-
-        def _mock_request(username: str, json: Any):
-            return mock.get(
-                f"https://www.reddit.com/user/{username}/about.json",
-                match=[
-                    matchers.header_matcher({"user-agent": USER_AGENT}),
-                ],
-                json=json,
-            )
-
-        yield _mock_request
+        yield _build_mock_user_request(mock)
 
 
 @pytest.fixture
@@ -591,6 +810,14 @@ def comments_file(archive_dir: Path):
 @pytest.fixture
 def posts_file(archive_dir: Path):
     return _build_test_file(archive_dir, "posts.csv", ["id", "d", "e", "f"])
+
+
+@pytest.fixture
+def empty_file_at_path(archive_dir: Path):
+    def _empty_file(filename: str):
+        return _build_test_file(archive_dir, filename, [])
+
+    return _empty_file
 
 
 # ---

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,18 +1,19 @@
 from traceback import print_tb
+
 import pytest
-from click.testing import CliRunner
 import responses
+from click.testing import CliRunner
 from sqlite_utils import Database
 
 from reddit_user_to_sqlite.cli import add_missing_user_fragment, cli
 from tests.conftest import (
     MockInfoFunc,
     MockPagedFunc,
-    _wrap_response,
-    _build_test_file,
     _build_mock_info_req,
     _build_mock_paged_req,
     _build_mock_user_request,
+    _build_test_file,
+    _wrap_response,
 )
 
 

--- a/tests/test_csv_helpers.py
+++ b/tests/test_csv_helpers.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+
 import pytest
 from sqlite_utils import Database
 

--- a/tests/test_csv_helpers.py
+++ b/tests/test_csv_helpers.py
@@ -1,0 +1,92 @@
+from pathlib import Path
+import pytest
+from sqlite_utils import Database
+
+from reddit_user_to_sqlite.csv_helpers import (
+    get_username_from_archive,
+    load_ids_from_file,
+    validate_and_build_path,
+)
+
+
+def test_validate_and_build_path(archive_dir, stats_file):
+    assert validate_and_build_path(archive_dir, "statistics") == stats_file
+
+
+def test_validate_and_build_fails(archive_dir: Path):
+    with pytest.raises(ValueError) as err:
+        validate_and_build_path(archive_dir, "posts")
+
+    err_msg = str(err.value)
+
+    assert str(archive_dir) in err_msg
+    assert "posts.csv not found" in err_msg
+
+
+def test_load_comment_ids_from_file_empty_db(
+    tmp_db: Database, archive_dir, comments_file
+):
+    assert load_ids_from_file(tmp_db, archive_dir, "comments") == [
+        "t1_a",
+        "t1_b",
+        "t1_c",
+    ]
+
+
+def test_load_comment_ids_from_file_some_db(
+    tmp_db: Database, archive_dir, comments_file
+):
+    tmp_db["comments"].insert({"id": "a"})  # type: ignore
+
+    assert load_ids_from_file(tmp_db, archive_dir, "comments") == [
+        "t1_b",
+        "t1_c",
+    ]
+
+
+def test_load_comment_ids_missing_files(tmp_db: Database, archive_dir):
+    with pytest.raises(ValueError) as err:
+        load_ids_from_file(tmp_db, archive_dir, "comments")
+
+    err_msg = str(err)
+    assert "comments.csv not found" in err_msg
+
+
+def test_load_post_ids_from_file_empty_db(tmp_db: Database, archive_dir, posts_file):
+    assert load_ids_from_file(tmp_db, archive_dir, "posts") == [
+        "t3_d",
+        "t3_e",
+        "t3_f",
+    ]
+
+
+def test_load_post_ids_from_file_some_db(tmp_db: Database, archive_dir, posts_file):
+    tmp_db["posts"].insert({"id": "e"})  # type: ignore
+
+    assert load_ids_from_file(tmp_db, archive_dir, "posts") == [
+        "t3_d",
+        "t3_f",
+    ]
+
+
+def test_load_post_ids_missing_files(tmp_db: Database, archive_dir):
+    with pytest.raises(ValueError) as err:
+        load_ids_from_file(tmp_db, archive_dir, "posts")
+
+    assert "posts.csv not found" in str(err.value)
+
+
+def test_get_username_from_archive(archive_dir, stats_file):
+    assert get_username_from_archive(archive_dir) == "xavdid"
+
+
+def test_get_username_from_archive_no_name(archive_dir: Path):
+    (archive_dir / "statistics.csv").touch()
+    assert get_username_from_archive(archive_dir) == None
+
+
+def test_get_username_from_archive_missing_file(archive_dir):
+    with pytest.raises(ValueError) as err:
+        get_username_from_archive(archive_dir)
+
+    assert "statistics.csv not found" in str(err.value)

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,6 +1,6 @@
 import pytest
 
-from reddit_user_to_sqlite.helpers import clean_username, any_object_has_username
+from reddit_user_to_sqlite.helpers import clean_username, find_user_details_from_items
 
 
 @pytest.mark.parametrize(
@@ -26,9 +26,14 @@ def test_unique_fixture_ids(self_post, removed_post, external_post):
     assert len({p["id"] for p in [self_post, removed_post, external_post]}) == 3
 
 
-def test_verify_username():
-    assert any_object_has_username([{"asdf": 1}, {"author_fullname": "xavdid"}]) == True
+def test_find_user_details_from_items():
+    assert find_user_details_from_items(
+        [
+            {"asdf": 1},
+            {"author_fullname": "t2_abc123", "author": "xavdid"},
+        ]
+    ) == ("xavdid", "t2_abc123")
 
 
-def test_failing_verify_username():
-    assert any_object_has_username([{"asdf": 1}, {"author": "xavdid"}]) == False
+def test_fail_to_find_user_details_from_items():
+    assert find_user_details_from_items([{"asdf": 1}, {"author": "xavdid"}]) == None

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,6 +1,6 @@
 import pytest
 
-from reddit_user_to_sqlite.helpers import clean_username
+from reddit_user_to_sqlite.helpers import clean_username, any_object_has_username
 
 
 @pytest.mark.parametrize(
@@ -24,3 +24,11 @@ def test_fixture_modifications(self_post, removed_post):
 def test_unique_fixture_ids(self_post, removed_post, external_post):
     # all post types should have unique ids
     assert len({p["id"] for p in [self_post, removed_post, external_post]}) == 3
+
+
+def test_verify_username():
+    assert any_object_has_username([{"asdf": 1}, {"author_fullname": "xavdid"}]) == True
+
+
+def test_failing_verify_username():
+    assert any_object_has_username([{"asdf": 1}, {"author": "xavdid"}]) == False

--- a/tests/test_reddit_api.py
+++ b/tests/test_reddit_api.py
@@ -4,13 +4,13 @@ import pytest
 
 from reddit_user_to_sqlite.reddit_api import (
     SuccessResponse,
+    _raise_reddit_error,
     get_user_id,
     load_comments_for_user,
     load_info,
     load_posts_for_user,
-    _raise_reddit_error,
 )
-from tests.conftest import MockInfoFunc, MockPagedFunc, MockUserFunc, empty_response
+from tests.conftest import MockInfoFunc, MockPagedFunc, MockUserFunc
 
 
 def test_load_comments(mock_paged_request: MockPagedFunc, comment_response, comment):

--- a/tests/test_reddit_api.py
+++ b/tests/test_reddit_api.py
@@ -5,29 +5,30 @@ import pytest
 from reddit_user_to_sqlite.reddit_api import (
     SuccessResponse,
     load_comments_for_user,
+    load_info,
     load_posts_for_user,
 )
-from tests.conftest import MockFunc
+from tests.conftest import MockInfoFunc, MockPagedFunc
 
 
-def test_load_comments(mock_request: MockFunc, comment_response, comment):
-    response = mock_request(resource="comments", json=comment_response)
+def test_load_comments(mock_paged_request: MockPagedFunc, comment_response, comment):
+    response = mock_paged_request(resource="comments", json=comment_response)
 
     assert load_comments_for_user("xavdid") == [comment]
 
     assert response.call_count == 1
 
 
-def test_load_posts(mock_request: MockFunc, self_post_response, self_post):
-    response = mock_request(resource="submitted", json=self_post_response)
+def test_load_posts(mock_paged_request: MockPagedFunc, self_post_response, self_post):
+    response = mock_paged_request(resource="submitted", json=self_post_response)
 
     assert load_posts_for_user("xavdid") == [self_post]
     assert response.call_count == 1
 
 
 @patch("reddit_user_to_sqlite.reddit_api.PAGE_SIZE", new=1)
-def test_loads_10_pages(mock_request: MockFunc, comment_response, comment):
-    response = mock_request(
+def test_loads_10_pages(mock_paged_request: MockPagedFunc, comment_response, comment):
+    response = mock_paged_request(
         resource="comments", params={"limit": 1}, json=comment_response
     )
 
@@ -38,20 +39,20 @@ def test_loads_10_pages(mock_request: MockFunc, comment_response, comment):
 
 @patch("reddit_user_to_sqlite.reddit_api.PAGE_SIZE", new=1)
 def test_loads_multiple_pages(
-    mock_request: MockFunc, comment_response: SuccessResponse, comment
+    mock_paged_request: MockPagedFunc, comment_response: SuccessResponse, comment
 ):
     comment_response["data"]["after"] = "abc"
-    first_request = mock_request(
+    first_request = mock_paged_request(
         resource="comments", params={"limit": 1}, json=comment_response
     )
 
     comment_response["data"]["after"] = "def"
-    second_request = mock_request(
+    second_request = mock_paged_request(
         resource="comments", params={"limit": 1, "after": "abc"}, json=comment_response
     )
 
     comment_response["data"]["children"] = []
-    third_request = mock_request(
+    third_request = mock_paged_request(
         resource="comments", params={"limit": 1, "after": "def"}, json=comment_response
     )
 
@@ -64,8 +65,8 @@ def test_loads_multiple_pages(
     assert comments == [comment, comment]
 
 
-def test_error_response(mock_request: MockFunc):
-    mock_request(
+def test_error_response(mock_paged_request: MockPagedFunc):
+    mock_paged_request(
         resource="comments", json={"error": 500, "message": "you broke reddit"}
     )
 
@@ -75,3 +76,18 @@ def test_error_response(mock_request: MockFunc):
     assert (
         str(err.value) == "Received API error from Reddit (code 500): you broke reddit"
     )
+
+
+def test_load_info(mock_info_request: MockInfoFunc, comment_response, comment):
+    mock_info_request("a,b,c", json=comment_response)
+
+    assert load_info(["a", "b", "c"]) == [comment]
+
+
+@patch("reddit_user_to_sqlite.reddit_api.PAGE_SIZE", new=2)
+def test_load_info_pages(mock_info_request: MockInfoFunc, comment_response, comment):
+    mock_info_request("a,b", json=comment_response, limit=2)
+    mock_info_request("c,d", json=comment_response, limit=2)
+    mock_info_request("e,f", json=comment_response, limit=2)
+
+    assert load_info(["a", "b", "c", "d", "e", "f"]) == [comment] * 3

--- a/tests/test_sqlite_helpers.py
+++ b/tests/test_sqlite_helpers.py
@@ -9,10 +9,10 @@ from reddit_user_to_sqlite.reddit_api import Comment, SubredditFragment, UserFra
 from reddit_user_to_sqlite.sqlite_helpers import (
     CommentRow,
     comment_to_comment_row,
-    item_to_subreddit_row,
-    item_to_user_row,
     insert_subreddits,
     insert_user,
+    item_to_subreddit_row,
+    item_to_user_row,
     post_to_post_row,
     upsert_comments,
     upsert_posts,
@@ -124,7 +124,7 @@ def test_insert_comments(tmp_db: Database, comment, stored_comment: CommentRow):
     failure_reasons = []
     for k in ["user", "subreddit"]:
         try:
-            tmp_db[f"{k}s"].get(stored_comment[k])
+            tmp_db[f"{k}s"].get(stored_comment[k])  # type: ignore
         except NotFoundError:
             failure_reasons.append(f"broken foreign key relationship for comment.{k}")
 
@@ -143,7 +143,7 @@ def test_update_comments(tmp_db: Database, comment: Comment, stored_comment):
     comment["score"] = 10
     upsert_comments(tmp_db, [comment])
 
-    updated_comment = tmp_db["comments"].get(comment["id"])
+    updated_comment = tmp_db["comments"].get(comment["id"])  # type: ignore
     assert updated_comment["score"] == 10
 
 
@@ -182,7 +182,7 @@ def test_insert_posts(
     failure_reasons = []
     for k in ["user", "subreddit"]:
         try:
-            tmp_db[f"{k}s"].get(stored_post[k])
+            tmp_db[f"{k}s"].get(stored_post[k])  # type: ignore
         except NotFoundError:
             failure_reasons.append(f"broken foreign key relationship for comment.{k}")
 


### PR DESCRIPTION
TODO: 

- [x] add support for posts
- [ ] if a comment has been removed, fall back to cached data (I _think_ all I need is the comment body itself; everything else probably still comes back from the API?)
- [x] if all unsaved comments are removed, my method of using the first loaded comment to get the user won't work. Could probably look in the DB and see if it's a single-user database. If not, I could load the first 100 archived comments and see if any of them aren't removed. if none of those work, I guess I'd need user input
- [ ] I _should_ overwrite comments that are stored as `[removed]` (though there shouldn't be any of those in wild dbs yet)
- [x] clean up shared code
- [x] add support for removed posts