### PR TITLE
Add Python 3.10 support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
   "click==8.1.3",
   "requests==2.29.0",
   "tqdm==4.65.0",
+  "typing_extensions==4.6.3",
 ]
 
 [project.optional-dependencies]

--- a/reddit_user_to_sqlite/reddit_api.py
+++ b/reddit_user_to_sqlite/reddit_api.py
@@ -1,7 +1,7 @@
+from typing_extensions import NotRequired
 from typing import (
     Any,
     Literal,
-    NotRequired,
     Optional,
     Sequence,
     TypedDict,


### PR DESCRIPTION
NotRequired is a Python 3.11 addition. By using typing_extensions we can get support for it in Python 3.10.