### PR TITLE
Fix HTTP 429 throttling errors: add API backoff and rate limiting.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -178,3 +178,5 @@ pyrightconfig.json
 *.db
 config.json
 metadata.json
+
+launch.json

--- a/reddit_user_to_sqlite/reddit_api.py
+++ b/reddit_user_to_sqlite/reddit_api.py
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
 
 import requests
 import logging
+import click
 from tqdm import tqdm, trange
 
 from reddit_user_to_sqlite.helpers import batched
@@ -196,7 +197,7 @@ def load_info(resources: Sequence[str]) -> list[Union[Comment, Post]]:
     result = []
     slowMode = len(resources) > 10000
     if slowMode:
-        print("Large data pull detected, enabling slow mode to prevent API rate limiting")
+        click.echo("Large data pull detected, enabling slow mode to prevent API rate limiting")
     for batch in batched(
         tqdm(resources, disable=bool(os.environ.get("DISABLE_PROGRESS"))), PAGE_SIZE
     ):
@@ -213,7 +214,7 @@ def load_info(resources: Sequence[str]) -> list[Union[Comment, Post]]:
                logging.exception(e)
                if i == MAX_RETRIES - 1:
                    # if we're out of retries, return what we have
-                   print("Max retries exceeded, returning partial result")
+                   click.echo("Max retries exceeded, returning partial result")
                    return result
                # sleep tops out at 256 seconds with MAX_RETRIES = 8
                time.sleep(2 ** i)

--- a/reddit_user_to_sqlite/reddit_api.py
+++ b/reddit_user_to_sqlite/reddit_api.py
@@ -253,7 +253,3 @@ def add_missing_user_fragment(
         else i
         for i in items
     ]
-
-
-
-


### PR DESCRIPTION
Addresses issue https://github.com/xavdid/reddit-user-to-sqlite/issues/23.  I was getting 429 errors, after this PR I was able to download all 16k of my comments without fail.

This PR adds rate limiting on API calls to get comments, with delays between requests for batches more than 10k comments, and also adds retries with exponential backoff for general errors.

I'd like to celebrate my first open source PR with an emoji 🎉